### PR TITLE
go.mod: Bump to golang 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/heathcliff26/speedtest-exporter
 
-go 1.22.0
-
-toolchain go1.23.1
+go 1.23
 
 require (
 	github.com/heathcliff26/promremote v1.0.6


### PR DESCRIPTION
The new dependencies want toolchain 1.23, so it makes sense to just bump the go version to 1.23 and drop the toolchain directive.