### PR TITLE
go.mod: Update go version to 1.N.P notation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heathcliff26/speedtest-exporter
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/heathcliff26/promremote v1.0.8


### PR DESCRIPTION
According to CodeQL:
As of Go 1.21, toolchain versions must use the 1.N.P syntax.