### PR TITLE
Fix code alerts found by gosec

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,6 +67,7 @@ func LoadConfig(path string, env bool) (Config, error) {
 		return c, nil
 	}
 
+	// #nosec G304: Local users can decide on the config file path freely.
 	f, err := os.ReadFile(path)
 	if err != nil {
 		return Config{}, err


### PR DESCRIPTION
Ensure that the http server times out after 10 seconds. As all files send are
small, this static timeout should be good enough.

Add #nosec comments with justification where appropiate.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>