### PR TITLE
Increase http write timeout

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/heathcliff26/speedtest-exporter/pkg/collector"
+	"github.com/heathcliff26/speedtest-exporter/pkg/config"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServerRootHandler(t *testing.T) {
@@ -42,4 +48,46 @@ func TestCreateSpeedtest(t *testing.T) {
 		}
 		assert.Equal(t, "*speedtest.SpeedtestGo", reflect.TypeOf(s).String())
 	})
+}
+
+func TestServerWriteTimeout(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s, err := createSpeedtest("")
+	require.NoError(err, "Should create speedtest")
+	c, err := collector.NewCollector(-1, s) // Ensure we do not use a cache
+	require.NoError(err, "Should create collector")
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(c)
+
+	server := createServer(config.DEFAULT_PORT, reg) // Use port 0 to let the OS assign a free port
+	require.NotNil(server, "Server should not be nil")
+
+	serverError := make(chan error, 1)
+	go func() {
+		err := server.ListenAndServe()
+		if err == http.ErrServerClosed {
+			err = nil
+		}
+		serverError <- err
+	}()
+
+	addr := fmt.Sprintf("http://localhost:%d", config.DEFAULT_PORT)
+
+	require.Eventually(func() bool {
+		res, err := http.Get(addr)
+		if err == nil && res.StatusCode == http.StatusOK {
+			return true
+		}
+		return false
+	}, 1*time.Minute, 10*time.Second, "Server should start within 1 minute")
+
+	res, err := http.Get(addr + "/metrics")
+	require.NoError(err, "Should be able to get metrics")
+	assert.Equal(http.StatusOK, res.StatusCode, "Should return status OK")
+
+	assert.NoError(server.Shutdown(t.Context()), "Server should shut down without error")
+	assert.NoError(<-serverError, "Server should not return an error on shutdown")
 }


### PR DESCRIPTION
speedtests take longer to finish than the current write timeout.
This causes requests for metrics to fail when no result is cached.
Increase the timeout to accomodate the likely worst case scenario.

Fixes: #98

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>