### PR TITLE
Implement persistent caching of results across restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ WORKDIR /
 
 COPY --from=build-stage /app/bin/speedtest-exporter /
 
+VOLUME /cache
+
 EXPOSE 8080
 
 USER 1001

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -62,6 +62,8 @@ WORKDIR /
 
 COPY --from=combine-stage / /
 
+VOLUME /cache
+
 EXPOSE 8080
 
 USER 1001

--- a/README.md
+++ b/README.md
@@ -54,7 +54,12 @@ To run the image with default settings simply use:
 ```
 podman run -d -p 8080:8080 ghcr.io/heathcliff26/speedtest-exporter:slim
 ```
-You can then view you metrics under `http://localhost:8080/metrics`
+You can then view your metrics under `http://localhost:8080/metrics`.
+
+By default the last result will be cached to disk. To persist this between container runs, mount a volume at `/cache`:
+```
+podman run -d -p 8080:8080 -v speedtest-cache:/cache ghcr.io/heathcliff26/speedtest-exporter:slim
+```
 
 ## Configuration
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/heathcliff26/promremote/promremote"
+	"github.com/heathcliff26/speedtest-exporter/pkg/cache"
 	"github.com/heathcliff26/speedtest-exporter/pkg/collector"
 	"github.com/heathcliff26/speedtest-exporter/pkg/config"
 	"github.com/heathcliff26/speedtest-exporter/pkg/speedtest"
@@ -83,7 +84,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	collector, err := collector.NewCollector(time.Duration(cfg.Cache), s)
+	resultCache := cache.NewCache(cfg.PersistCache, "/cache/speedtest-result.json", time.Duration(cfg.Cache))
+
+	collector, err := collector.NewCollector(resultCache, s)
 	if err != nil {
 		slog.Error("Failed to create collector", "err", err)
 		os.Exit(1)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -17,9 +17,7 @@ import (
 
 func TestServerRootHandler(t *testing.T) {
 	req, err := http.NewRequest("GET", "/", nil)
-	if err != nil {
-		t.Fatalf("Failed to create request: %v", err)
-	}
+	require.NoError(t, err, "Failed to create request")
 	rr := httptest.NewRecorder()
 
 	ServerRootHandler(rr, req)
@@ -36,16 +34,12 @@ func TestServerRootHandler(t *testing.T) {
 func TestCreateSpeedtest(t *testing.T) {
 	t.Run("SpeedtestCLI", func(t *testing.T) {
 		s, err := createSpeedtest("../pkg/speedtest/testdata/speedtest-cli.sh")
-		if err != nil {
-			t.Fatalf("Failed to create speedtest: %v", err)
-		}
+		require.NoError(t, err, "Should create speedtest-cli")
 		assert.Equal(t, "*speedtest.SpeedtestCLI", reflect.TypeOf(s).String())
 	})
 	t.Run("Speedtest", func(t *testing.T) {
 		s, err := createSpeedtest("")
-		if err != nil {
-			t.Fatalf("Failed to create speedtest: %v", err)
-		}
+		require.NoError(t, err, "Should create speedtest-cli")
 		assert.Equal(t, "*speedtest.SpeedtestGo", reflect.TypeOf(s).String())
 	})
 }
@@ -56,7 +50,7 @@ func TestServerWriteTimeout(t *testing.T) {
 
 	s, err := createSpeedtest("")
 	require.NoError(err, "Should create speedtest")
-	c, err := collector.NewCollector(-1, s) // Ensure we do not use a cache
+	c, err := collector.NewCollector(nil, s) // Ensure we do not use a cache
 	require.NoError(err, "Should create collector")
 
 	reg := prometheus.NewRegistry()

--- a/configs/example-config.yaml
+++ b/configs/example-config.yaml
@@ -7,6 +7,8 @@ port: 8080
 # Time for which the last speedtest result will be cached.
 # Also used for the interval in which remote_write is invoked when enabled
 cache: "5m"
+# Disable persisting the cache to disk by setting this to false
+persistCache: true
 # When not empty, tells the exporter to use an external speedtest-cli binary instead of using go-native implementation
 speedtestCLI: ""
 # Configure remote_write behaviour

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,120 @@
+package cache
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/heathcliff26/speedtest-exporter/pkg/speedtest"
+)
+
+type Cache struct {
+	persist      bool
+	path         string
+	cacheTime    time.Duration
+	cachedResult *speedtest.SpeedtestResult
+
+	sync.RWMutex
+}
+
+// Create a new Cache instance and try to initialize it from disk if persist is true.
+// If the path is not writable, the cache will not persist to disk.
+// This function does not fail if it cannot read from disk, it will just log the error.
+func NewCache(persist bool, path string, cacheTime time.Duration) *Cache {
+	cache := &Cache{
+		persist:   persist,
+		path:      path,
+		cacheTime: cacheTime,
+	}
+
+	if path == "" {
+		cache.persist = false
+	}
+	if !cache.persist {
+		return cache
+	}
+
+	// #nosec G302: Cache does not contain sensitive data, can be world readable
+	f, err := os.OpenFile(cache.path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		slog.Info("Failed to open cache file, will not persist cache to disk", slog.String("file", cache.path), slog.Any("error", err))
+		cache.persist = false
+		return cache
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		slog.Info("Could not initialize cache from disk", slog.String("file", cache.path), slog.Any("error", err))
+		return cache
+	}
+
+	cachedResult := &speedtest.SpeedtestResult{}
+	err = cachedResult.UnmarshalJSON(data)
+	if err != nil {
+		slog.Info("Could not unmarshal cache data from disk", slog.String("file", cache.path), slog.Any("error", err))
+	} else {
+		slog.Info("Initialized cache from disk", slog.String("path", cache.path))
+		cache.cachedResult = cachedResult
+	}
+	return cache
+}
+
+// Return the currently cached result and whether it is still valid.
+// This method is safe to call even if the Cache instance is nil.
+func (c *Cache) Read() (result *speedtest.SpeedtestResult, valid bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.RLock()
+	defer c.RUnlock()
+
+	if c.cachedResult == nil {
+		return nil, false
+	}
+
+	timestamp := c.cachedResult.TimestampAsTime()
+
+	return c.cachedResult, timestamp.Add(c.cacheTime).After(time.Now())
+}
+
+// Save the given result to the cache.
+// Attempt to persist to disk if enabled, but do not fail if it fails.
+// This method is safe to call even if the Cache instance is nil.
+func (c *Cache) Save(result *speedtest.SpeedtestResult) {
+	if c == nil {
+		return
+	}
+	c.Lock()
+	defer c.Unlock()
+
+	c.cachedResult = result
+	if !c.persist {
+		return
+	}
+
+	data, err := result.MarshalJSON()
+	if err != nil {
+		slog.Error("Could not marshal result to JSON", slog.Any("error", err))
+		return
+	}
+	// #nosec G306: Cache does not contain sensitive data, can be world readable
+	err = os.WriteFile(c.path, data, 0644)
+	if err != nil {
+		slog.Error("Could not write cache to disk", slog.String("file", c.path), slog.Any("error", err))
+	}
+}
+
+// Return when the cache will expire
+func (c *Cache) ExpiresAt() time.Time {
+	if c == nil || c.cachedResult == nil {
+		return time.Time{}
+	}
+	c.RLock()
+	defer c.RUnlock()
+
+	timestamp := c.cachedResult.TimestampAsTime()
+	return timestamp.Add(c.cacheTime)
+}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,198 @@
+package cache
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/heathcliff26/speedtest-exporter/pkg/speedtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCache(t *testing.T) {
+	tMatrix := []struct {
+		Name             string
+		Persist          bool
+		Path             string
+		ExpectedPersist  bool
+		ShouldHaveResult bool
+	}{
+		{
+			Name:             "EmptyPath",
+			Persist:          true,
+			Path:             "",
+			ExpectedPersist:  false,
+			ShouldHaveResult: false,
+		},
+		{
+			Name:             "NoPersist",
+			Persist:          false,
+			Path:             "testdata/result.json",
+			ExpectedPersist:  false,
+			ShouldHaveResult: false,
+		},
+		{
+			Name:             "PathDoesNotExist",
+			Persist:          true,
+			Path:             "/nonexistent/path/result.json",
+			ExpectedPersist:  false,
+			ShouldHaveResult: false,
+		},
+		{
+			Name:             "InvalidJSON",
+			Persist:          true,
+			Path:             "testdata/not-json.txt",
+			ExpectedPersist:  true,
+			ShouldHaveResult: false,
+		},
+		{
+			Name:             "InitializeFromFile",
+			Persist:          true,
+			Path:             "testdata/result.json",
+			ExpectedPersist:  true,
+			ShouldHaveResult: true,
+		},
+	}
+
+	for _, tCase := range tMatrix {
+		t.Run(tCase.Name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			cache := NewCache(tCase.Persist, tCase.Path, time.Minute)
+
+			assert.Equal(tCase.ExpectedPersist, cache.persist, "Persist flag should be set correctly")
+			assert.Equal(tCase.Path, cache.path, "Path should be set correctly")
+			assert.Equal(time.Minute, cache.cacheTime, "Cache time should be set correctly")
+			if tCase.ShouldHaveResult {
+				assert.NotNil(cache.cachedResult, "Cached result should be initialized")
+			} else {
+				assert.Nil(cache.cachedResult, "Cached result should be empty")
+			}
+		})
+	}
+}
+
+func TestCacheNil(t *testing.T) {
+	c := (*Cache)(nil)
+
+	t.Run("Read", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.NotPanics(func() {
+			_, _ = c.Read()
+		}, "Read should not panic on nil Cache")
+
+		result, valid := c.Read()
+		assert.Nil(result, "Cache should not return a result")
+		assert.False(valid, "Cache should not be valid")
+	})
+	t.Run("Save", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.NotPanics(func() {
+			c.Save(speedtest.NewFailedSpeedtestResult())
+		}, "Save should not panic on nil Cache")
+	})
+	t.Run("ExpiresAt", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.NotPanics(func() {
+			_ = c.ExpiresAt()
+		}, "ExpiresAt should not panic on nil Cache")
+		assert.Zero(c.ExpiresAt(), "Cache should return zero time")
+	})
+}
+
+func TestRead(t *testing.T) {
+	t.Run("EmptyCache", func(t *testing.T) {
+		assert := assert.New(t)
+
+		c := &Cache{
+			cacheTime: time.Minute,
+		}
+
+		result, valid := c.Read()
+		assert.Nil(result, "Should not return a result")
+		assert.False(valid, "Cache should not be valid")
+	})
+	t.Run("ValidResult", func(t *testing.T) {
+		assert := assert.New(t)
+
+		expectedResult := speedtest.NewFailedSpeedtestResult()
+		c := &Cache{
+			cacheTime:    time.Minute,
+			cachedResult: expectedResult,
+		}
+
+		result, valid := c.Read()
+		assert.Equal(expectedResult, result, "Should return cached result")
+		assert.True(valid, "Cache should be valid")
+	})
+	t.Run("ExpiredCache", func(t *testing.T) {
+		assert := assert.New(t)
+
+		expectedResult := speedtest.NewFailedSpeedtestResult()
+		expectedResult.DebugSetTimestamp(time.Now().Add(-2 * time.Minute))
+		c := &Cache{
+			cacheTime:    time.Minute,
+			cachedResult: expectedResult,
+		}
+
+		result, valid := c.Read()
+		assert.Equal(expectedResult, result, "Should return cached result")
+		assert.False(valid, "Cache should not be valid")
+	})
+}
+
+func TestSave(t *testing.T) {
+	t.Run("DoNotPersist", func(t *testing.T) {
+		assert := assert.New(t)
+
+		c := &Cache{
+			path:      t.TempDir() + "/cache_test_save.json",
+			cacheTime: time.Minute,
+			persist:   false,
+		}
+
+		expectedResult := speedtest.NewFailedSpeedtestResult()
+		c.Save(expectedResult)
+
+		_, err := os.Stat(c.path)
+		assert.True(os.IsNotExist(err), "Cache file should not be created when persist is false")
+		assert.Equal(expectedResult, c.cachedResult, "Should cache the result")
+	})
+	t.Run("PersistToDisk", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		c := &Cache{
+			path:      t.TempDir() + "/cache_test_save.json",
+			cacheTime: time.Minute,
+			persist:   true,
+		}
+
+		expectedResult := speedtest.NewFailedSpeedtestResult()
+		c.Save(expectedResult)
+
+		assert.Equal(expectedResult, c.cachedResult, "Should cache the result")
+
+		data, err := os.ReadFile(c.path)
+		require.NoError(err, "Cache file should be created when persist is true")
+
+		diskResult := &speedtest.SpeedtestResult{}
+		err = diskResult.UnmarshalJSON(data)
+		require.NoError(err, "Should unmarshal cached result from disk")
+		assert.Equal(expectedResult, diskResult, "Cached result on disk should match expected result")
+	})
+}
+
+func TestExpiresAt(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedResult := speedtest.NewFailedSpeedtestResult()
+	c := &Cache{
+		cacheTime:    time.Minute,
+		cachedResult: expectedResult,
+	}
+	expectedExpiry := expectedResult.TimestampAsTime().Add(c.cacheTime)
+
+	assert.Equal(expectedExpiry, c.ExpiresAt(), "ExpiresAt should return correct expiry time")
+}

--- a/pkg/cache/testdata/not-json.txt
+++ b/pkg/cache/testdata/not-json.txt
@@ -1,0 +1,1 @@
+This is not json

--- a/pkg/cache/testdata/result.json
+++ b/pkg/cache/testdata/result.json
@@ -1,0 +1,13 @@
+{
+  "jitter_latency_ms": 0.5,
+  "ping_ms": 15,
+  "download_mbps": 876.53,
+  "upload_mbps": 12.34,
+  "data_used_mb": 950.3079,
+  "server_id": "1234",
+  "server_host": "example.org",
+  "client_isp": "Foo Corp.",
+  "client_ip": "127.0.0.1",
+  "success": true,
+  "timestamp": 1762786565082
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	DEFAULT_LOG_LEVEL = "info"
-	DEFAULT_PORT      = 8080
-	DEFAULT_CACHE     = Duration(5 * time.Minute)
+	DEFAULT_LOG_LEVEL     = "info"
+	DEFAULT_PORT          = 8080
+	DEFAULT_CACHE         = Duration(5 * time.Minute)
+	DEFAULT_PERSIST_CACHE = true
 )
 
 var logLevel *slog.LevelVar
@@ -32,6 +33,7 @@ type Config struct {
 	LogLevel     string       `json:"logLevel,omitempty"`
 	Port         int          `json:"port,omitempty"`
 	Cache        Duration     `json:"cache,omitempty"`
+	PersistCache bool         `json:"persistCache,omitempty"`
 	SpeedtestCLI string       `json:"speedtestCLI,omitempty"`
 	Remote       RemoteConfig `json:"remote,omitempty"`
 }
@@ -47,9 +49,10 @@ type RemoteConfig struct {
 // Returns a Config with default values set
 func DefaultConfig() Config {
 	return Config{
-		LogLevel: DEFAULT_LOG_LEVEL,
-		Port:     DEFAULT_PORT,
-		Cache:    DEFAULT_CACHE,
+		LogLevel:     DEFAULT_LOG_LEVEL,
+		Port:         DEFAULT_PORT,
+		Cache:        DEFAULT_CACHE,
+		PersistCache: DEFAULT_PERSIST_CACHE,
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,12 +16,14 @@ func TestValidConfigs(t *testing.T) {
 		LogLevel:     "warn",
 		Port:         80,
 		Cache:        Duration(time.Minute),
+		PersistCache: false,
 		SpeedtestCLI: "/path/to/speedtest",
 	}
 	c2 := Config{
-		LogLevel: "debug",
-		Port:     2080,
-		Cache:    Duration(30 * time.Minute),
+		LogLevel:     "debug",
+		Port:         2080,
+		Cache:        Duration(30 * time.Minute),
+		PersistCache: true,
 		Remote: RemoteConfig{
 			Enable:   true,
 			URL:      "https://example.org/",
@@ -31,9 +33,10 @@ func TestValidConfigs(t *testing.T) {
 		},
 	}
 	c3 := Config{
-		LogLevel: "error",
-		Port:     DEFAULT_PORT,
-		Cache:    DEFAULT_CACHE,
+		LogLevel:     "error",
+		Port:         DEFAULT_PORT,
+		Cache:        DEFAULT_CACHE,
+		PersistCache: DEFAULT_PERSIST_CACHE,
 		Remote: RemoteConfig{
 			Enable:   true,
 			URL:      "https://example.org/",
@@ -121,9 +124,10 @@ func TestInvalidConfig(t *testing.T) {
 
 func TestEnvSubstitution(t *testing.T) {
 	c := Config{
-		LogLevel: "debug",
-		Port:     2080,
-		Cache:    Duration(time.Minute),
+		LogLevel:     "debug",
+		Port:         2080,
+		Cache:        Duration(time.Minute),
+		PersistCache: DEFAULT_PERSIST_CACHE,
 	}
 	t.Setenv("SPEEDTEST_TEST_LOG_LEVEL", c.LogLevel)
 	t.Setenv("SPEEDTEST_TEST_PORT", strconv.Itoa(c.Port))
@@ -156,7 +160,7 @@ func TestSetLogLevel(t *testing.T) {
 	t.Cleanup(func() {
 		err := setLogLevel(DEFAULT_LOG_LEVEL)
 		if err != nil {
-			t.Fatalf("Failed to cleanup after test: %v", err)
+			t.Logf("Failed to cleanup after test: %v", err)
 		}
 	})
 

--- a/pkg/config/testdata/valid-config-1.yaml
+++ b/pkg/config/testdata/valid-config-1.yaml
@@ -1,4 +1,5 @@
 logLevel: "warn"
 port: 80
 cache: "1m"
+persistCache: false
 speedtestCLI: "/path/to/speedtest"

--- a/pkg/config/testdata/valid-config-2.yaml
+++ b/pkg/config/testdata/valid-config-2.yaml
@@ -1,6 +1,7 @@
 logLevel: "debug"
 port: 2080
 cache: "30m"
+persistCache: true
 remote:
   enable: true
   url: "https://example.org/"

--- a/pkg/speedtest/speedtest-cli_test.go
+++ b/pkg/speedtest/speedtest-cli_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewSpeedtestCLI(t *testing.T) {
@@ -19,18 +20,14 @@ func TestNewSpeedtestCLI(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		s, err := NewSpeedtestCLI("testdata/speedtest-cli.sh")
-		if err != nil {
-			t.Fatalf("Failed to create speedtest-cli: %v", err)
-		}
+		require.NoError(t, err, "Should create speedtest-cli")
 		assert.Contains(s.Path(), "testdata/speedtest-cli.sh")
 	})
 }
 
 func TestRunSpeedtestForCLI(t *testing.T) {
 	s, err := NewSpeedtestCLI("testdata/speedtest-cli.sh")
-	if err != nil {
-		t.Fatalf("Failed to create speedtest-cli: %v", err)
-	}
+	require.NoError(t, err, "Should create speedtest-cli")
 	makeCmd = func(path string) *exec.Cmd {
 		return exec.Command("bash", "-c", path)
 	}
@@ -38,6 +35,8 @@ func TestRunSpeedtestForCLI(t *testing.T) {
 	expectedResult := NewSpeedtestResult(0.629, 17.148, 931.564032, 49.4518, 1141.3079899999998, "60440", "speedtest.hannover.jonasdevries.de", "Some ISP", "100.107.156.96")
 
 	result := s.Speedtest()
+
+	expectedResult.timestamp = result.timestamp // sync timestamps for comparison
 
 	assert.Equal(t, result, expectedResult)
 }

--- a/pkg/speedtest/speedtest-go_test.go
+++ b/pkg/speedtest/speedtest-go_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRunSpeedtestForGo(t *testing.T) {
@@ -13,9 +14,7 @@ func TestRunSpeedtestForGo(t *testing.T) {
 
 	s := NewSpeedtest()
 	result := s.Speedtest()
-	if !result.Success() {
-		t.Fatal("Speedtest returned with failure")
-	}
+	require.True(t, result.Success(), "Speedtest should succeed")
 
 	assert := assert.New(t)
 	assert.NotEmpty(result)

--- a/pkg/speedtest/types_test.go
+++ b/pkg/speedtest/types_test.go
@@ -2,18 +2,26 @@ package speedtest
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewFailedSpeedtestResult(t *testing.T) {
+	assert := assert.New(t)
 	var expectedResult = &SpeedtestResult{
 		success: false,
 	}
-	assert.Equal(t, expectedResult, NewFailedSpeedtestResult())
+
+	result := NewFailedSpeedtestResult()
+	assert.NotZero(result.Timestamp(), "Failed result should have timestamp")
+	expectedResult.timestamp = result.timestamp // align timestamps for comparison
+	assert.Equal(expectedResult, result, "Should match expected failed SpeedtestResult")
 }
 
 func TestNewSpeedtestResult(t *testing.T) {
+	assert := assert.New(t)
+
 	var expectedResult = &SpeedtestResult{
 		jitterLatency: 0.5,
 		ping:          15,
@@ -26,6 +34,36 @@ func TestNewSpeedtestResult(t *testing.T) {
 		clientIP:      "127.0.0.1",
 		success:       true,
 	}
+
 	actualResult := NewSpeedtestResult(0.5, 15, 876.53, 12.34, 950.3079, "1234", "example.org", "Foo Corp.", "127.0.0.1")
-	assert.Equal(t, expectedResult, actualResult)
+
+	assert.InDelta(time.Now().UnixMilli(), actualResult.Timestamp(), 10, "Timestamp should be close to current time")
+	expectedResult.timestamp = actualResult.timestamp // align timestamps for comparison
+	assert.Equal(expectedResult, actualResult, "NewSpeedtestResult should create the expected SpeedtestResult")
+}
+
+func TestSpeedtestResultJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	result := NewSpeedtestResult(0.5, 15, 876.53, 12.34, 950.3079, "1234", "example.org", "Foo Corp.", "127.0.0.1")
+
+	jsonData, err := result.MarshalJSON()
+	assert.NoError(err, "Should marshal SpeedtestResult to JSON without error")
+
+	unmarshaledResult := &SpeedtestResult{}
+	err = unmarshaledResult.UnmarshalJSON(jsonData)
+	assert.NoError(err, "Should unmarshal JSON to SpeedtestResult without error")
+
+	assert.Equal(result, unmarshaledResult, "Unmarshaled result should match the original")
+
+	failedMarshal := &SpeedtestResult{}
+	err = failedMarshal.UnmarshalJSON([]byte("not-valid-json"))
+	assert.Error(err, "Should return error when unmarshaling invalid JSON")
+	assert.Empty(failedMarshal, "Should not change anything in the target variable")
+}
+
+func TestSpeedtestResultTimestampAsTime(t *testing.T) {
+	r := NewSpeedtestResult(0.5, 15, 876.53, 12.34, 950.3079, "1234", "example.org", "Foo Corp.", "127.0.0.1")
+
+	assert.Equal(t, time.UnixMilli(r.timestamp), r.TimestampAsTime(), "TimestampAsTime should return correct time.Time representation")
 }


### PR DESCRIPTION
Ensure that the cache remains valid between restarts by storing it on disk.
To ensure the cache does not introduces a failure point, it will not fail when
it occurs an error.

Additionally replace t.Fatal for require in unit-tests for better readability.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>