### PR TITLE
cache: Fix wrong error message when cache file is empty

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -51,6 +51,11 @@ func NewCache(persist bool, path string, cacheTime time.Duration) *Cache {
 		return cache
 	}
 
+	if len(data) == 0 {
+		slog.Info("Cache file is empty, starting with empty cache", slog.String("file", cache.path))
+		return cache
+	}
+
 	cachedResult := &speedtest.SpeedtestResult{}
 	err = cachedResult.UnmarshalJSON(data)
 	if err != nil {


### PR DESCRIPTION
When the cache is empty, it means it has not been used yet.
This should not result in an error message.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>