### PR TITLE
Use speedtest-exporter as default job name when pushing metrics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -96,7 +96,7 @@ func main() {
 	reg.MustRegister(collector)
 
 	if cfg.Remote.Enable {
-		rwClient, err := promremote.NewWriteClient(cfg.Remote.URL, cfg.Remote.Instance, "integrations/speedtest", reg)
+		rwClient, err := promremote.NewWriteClient(cfg.Remote.URL, cfg.Remote.Instance, cfg.Remote.JobName, reg)
 		if err != nil {
 			slog.Error("Failed to create remote write client", "err", err)
 			os.Exit(1)

--- a/configs/example-config.yaml
+++ b/configs/example-config.yaml
@@ -19,6 +19,8 @@ remote:
   url: ""
   # Name of the instance, used to label metrics when performing remote_write. Defaults to hostname when empty
   instance: ""
+  # Name of job under which metrics will be pushed
+  jobName: "speedtest-exporter"
   # Username and password for Basic Authentication. Leave empty when not required
   username: ""
   password: ""

--- a/dashboard/dashboard.json
+++ b/dashboard/dashboard.json
@@ -730,7 +730,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values({job=\"integrations/speedtest\"},instance)",
+        "definition": "label_values({job=\"speedtest-exporter\"},instance)",
         "hide": 0,
         "includeAll": false,
         "label": "instance",
@@ -739,7 +739,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values({job=\"integrations/speedtest\"},instance)",
+          "query": "label_values({job=\"speedtest-exporter\"},instance)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	DEFAULT_LOG_LEVEL     = "info"
-	DEFAULT_PORT          = 8080
-	DEFAULT_CACHE         = Duration(5 * time.Minute)
-	DEFAULT_PERSIST_CACHE = true
+	DEFAULT_LOG_LEVEL       = "info"
+	DEFAULT_PORT            = 8080
+	DEFAULT_CACHE           = Duration(5 * time.Minute)
+	DEFAULT_PERSIST_CACHE   = true
+	DEFAULT_REMOTE_JOB_NAME = "speedtest-exporter"
 )
 
 var logLevel *slog.LevelVar
@@ -42,6 +43,7 @@ type RemoteConfig struct {
 	Enable   bool   `json:"enable"`
 	URL      string `json:"url"`
 	Instance string `json:"instance"`
+	JobName  string `json:"jobName,omitempty"`
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
 }
@@ -53,6 +55,9 @@ func DefaultConfig() Config {
 		Port:         DEFAULT_PORT,
 		Cache:        DEFAULT_CACHE,
 		PersistCache: DEFAULT_PERSIST_CACHE,
+		Remote: RemoteConfig{
+			JobName: DEFAULT_REMOTE_JOB_NAME,
+		},
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,6 +18,9 @@ func TestValidConfigs(t *testing.T) {
 		Cache:        Duration(time.Minute),
 		PersistCache: false,
 		SpeedtestCLI: "/path/to/speedtest",
+		Remote: RemoteConfig{
+			JobName: DEFAULT_REMOTE_JOB_NAME,
+		},
 	}
 	c2 := Config{
 		LogLevel:     "debug",
@@ -28,6 +31,7 @@ func TestValidConfigs(t *testing.T) {
 			Enable:   true,
 			URL:      "https://example.org/",
 			Instance: "test",
+			JobName:  "testjob",
 			Username: "somebody",
 			Password: "somebody's password",
 		},
@@ -41,6 +45,7 @@ func TestValidConfigs(t *testing.T) {
 			Enable:   true,
 			URL:      "https://example.org/",
 			Instance: "test",
+			JobName:  DEFAULT_REMOTE_JOB_NAME,
 		},
 	}
 	tMatrix := []struct {
@@ -123,12 +128,12 @@ func TestInvalidConfig(t *testing.T) {
 }
 
 func TestEnvSubstitution(t *testing.T) {
-	c := Config{
-		LogLevel:     "debug",
-		Port:         2080,
-		Cache:        Duration(time.Minute),
-		PersistCache: DEFAULT_PERSIST_CACHE,
-	}
+	c := DefaultConfig()
+	c.LogLevel = "debug"
+	c.Port = 2080
+	c.Cache = Duration(time.Minute)
+	c.PersistCache = DEFAULT_PERSIST_CACHE
+
 	t.Setenv("SPEEDTEST_TEST_LOG_LEVEL", c.LogLevel)
 	t.Setenv("SPEEDTEST_TEST_PORT", strconv.Itoa(c.Port))
 	t.Setenv("SPEEDTEST_TEST_CACHE", c.Cache.String())

--- a/pkg/config/testdata/valid-config-2.yaml
+++ b/pkg/config/testdata/valid-config-2.yaml
@@ -6,5 +6,6 @@ remote:
   enable: true
   url: "https://example.org/"
   instance: "test"
+  jobName: "testjob"
   username: "somebody"
   password: "somebody's password"


### PR DESCRIPTION
Make the job name more intuitive through dropping the integrations prefix.
Allow configuring the job name through config file.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>