### PR TITLE
Add instance label by default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	resultCache := cache.NewCache(cfg.PersistCache, "/cache/speedtest-result.json", time.Duration(cfg.Cache))
 
-	collector, err := collector.NewCollector(resultCache, s)
+	collector, err := collector.NewCollector(resultCache, s, cfg.Remote.Instance)
 	if err != nil {
 		slog.Error("Failed to create collector", "err", err)
 		os.Exit(1)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -50,7 +50,7 @@ func TestServerWriteTimeout(t *testing.T) {
 
 	s, err := createSpeedtest("")
 	require.NoError(err, "Should create speedtest")
-	c, err := collector.NewCollector(nil, s) // Ensure we do not use a cache
+	c, err := collector.NewCollector(nil, s, "testinstance") // Ensure we do not use a cache
 	require.NoError(err, "Should create collector")
 
 	reg := prometheus.NewRegistry()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,13 +50,19 @@ type RemoteConfig struct {
 
 // Returns a Config with default values set
 func DefaultConfig() Config {
+	hostname, err := os.Hostname()
+	if err != nil {
+		slog.Error("Failed to retrieve hostname, using localhost instead", "err", err)
+		hostname = "localhost"
+	}
 	return Config{
 		LogLevel:     DEFAULT_LOG_LEVEL,
 		Port:         DEFAULT_PORT,
 		Cache:        DEFAULT_CACHE,
 		PersistCache: DEFAULT_PERSIST_CACHE,
 		Remote: RemoteConfig{
-			JobName: DEFAULT_REMOTE_JOB_NAME,
+			Instance: hostname,
+			JobName:  DEFAULT_REMOTE_JOB_NAME,
 		},
 	}
 }
@@ -101,15 +107,6 @@ func LoadConfig(path string, env bool) (Config, error) {
 		}
 		if c.Remote.Username != c.Remote.Password && (c.Remote.Username == "" || c.Remote.Password == "") {
 			return Config{}, promremote.ErrMissingAuthCredentials{}
-		}
-		if c.Remote.Instance == "" {
-			slog.Info("No instance name provided, defaulting to hostname")
-			hostname, err := os.Hostname()
-			if err != nil {
-				slog.Error("Failed to retrieve hostname, using localhost instead", "err", err)
-				hostname = "localhost"
-			}
-			c.Remote.Instance = hostname
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -76,10 +76,16 @@ func TestValidConfigs(t *testing.T) {
 
 	for _, tCase := range tMatrix {
 		t.Run(tCase.Name, func(t *testing.T) {
+			assert := assert.New(t)
 			c, err := LoadConfig(tCase.Path, false)
 
+			if tCase.Result.Remote.Instance == "" {
+				assert.NotEmpty(c.Remote.Instance, "Instance should be set to hostname")
+				tCase.Result.Remote.Instance = c.Remote.Instance
+			}
+
 			require.NoError(t, err, "Should load config")
-			assert.Equal(t, tCase.Result, c)
+			assert.Equal(tCase.Result, c)
 		})
 	}
 }


### PR DESCRIPTION
Add the instance label by default. If none is given, fallback to the hostname.
This needs an update in promremote, as otherwise the label will be duplicated.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>