### PR TITLE
config: Move instance label to higher level

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	resultCache := cache.NewCache(cfg.PersistCache, "/cache/speedtest-result.json", time.Duration(cfg.Cache))
 
-	collector, err := collector.NewCollector(resultCache, s, cfg.Remote.Instance)
+	collector, err := collector.NewCollector(resultCache, s, cfg.Instance)
 	if err != nil {
 		slog.Error("Failed to create collector", "err", err)
 		os.Exit(1)

--- a/configs/example-config.yaml
+++ b/configs/example-config.yaml
@@ -4,6 +4,8 @@ logLevel: "info"
 
 # Port for the metrics server
 port: 8080
+# Name of the instance, used to label metrics. Defaults to hostname when empty
+instance: ""
 # Time for which the last speedtest result will be cached.
 # Also used for the interval in which remote_write is invoked when enabled
 cache: "5m"
@@ -17,7 +19,7 @@ remote:
   enable: false
   # URL to prometheus remote_write endpoint
   url: ""
-  # Name of the instance, used to label metrics when performing remote_write. Defaults to hostname when empty
+  # Overwrite the instance label for remote write.
   instance: ""
   # Name of job under which metrics will be pushed
   jobName: "speedtest-exporter"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ func init() {
 type Config struct {
 	LogLevel     string       `json:"logLevel,omitempty"`
 	Port         int          `json:"port,omitempty"`
+	Instance     string       `json:"instance,omitempty"`
 	Cache        Duration     `json:"cache,omitempty"`
 	PersistCache bool         `json:"persistCache,omitempty"`
 	SpeedtestCLI string       `json:"speedtestCLI,omitempty"`
@@ -42,7 +43,7 @@ type Config struct {
 type RemoteConfig struct {
 	Enable   bool   `json:"enable"`
 	URL      string `json:"url"`
-	Instance string `json:"instance"`
+	Instance string `json:"instance,omitempty"`
 	JobName  string `json:"jobName,omitempty"`
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
@@ -58,11 +59,11 @@ func DefaultConfig() Config {
 	return Config{
 		LogLevel:     DEFAULT_LOG_LEVEL,
 		Port:         DEFAULT_PORT,
+		Instance:     hostname,
 		Cache:        DEFAULT_CACHE,
 		PersistCache: DEFAULT_PERSIST_CACHE,
 		Remote: RemoteConfig{
-			Instance: hostname,
-			JobName:  DEFAULT_REMOTE_JOB_NAME,
+			JobName: DEFAULT_REMOTE_JOB_NAME,
 		},
 	}
 }
@@ -99,6 +100,10 @@ func LoadConfig(path string, env bool) (Config, error) {
 	err = setLogLevel(c.LogLevel)
 	if err != nil {
 		return Config{}, err
+	}
+
+	if c.Remote.Instance == "" {
+		c.Remote.Instance = c.Instance
 	}
 
 	if c.Remote.Enable {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,16 +15,19 @@ func TestValidConfigs(t *testing.T) {
 	c1 := Config{
 		LogLevel:     "warn",
 		Port:         80,
+		Instance:     "test",
 		Cache:        Duration(time.Minute),
 		PersistCache: false,
 		SpeedtestCLI: "/path/to/speedtest",
 		Remote: RemoteConfig{
-			JobName: DEFAULT_REMOTE_JOB_NAME,
+			JobName:  DEFAULT_REMOTE_JOB_NAME,
+			Instance: "test",
 		},
 	}
 	c2 := Config{
 		LogLevel:     "debug",
 		Port:         2080,
+		Instance:     "test",
 		Cache:        Duration(30 * time.Minute),
 		PersistCache: true,
 		Remote: RemoteConfig{
@@ -39,6 +42,7 @@ func TestValidConfigs(t *testing.T) {
 	c3 := Config{
 		LogLevel:     "error",
 		Port:         DEFAULT_PORT,
+		Instance:     "another-instance",
 		Cache:        DEFAULT_CACHE,
 		PersistCache: DEFAULT_PERSIST_CACHE,
 		Remote: RemoteConfig{
@@ -78,11 +82,6 @@ func TestValidConfigs(t *testing.T) {
 		t.Run(tCase.Name, func(t *testing.T) {
 			assert := assert.New(t)
 			c, err := LoadConfig(tCase.Path, false)
-
-			if tCase.Result.Remote.Instance == "" {
-				assert.NotEmpty(c.Remote.Instance, "Instance should be set to hostname")
-				tCase.Result.Remote.Instance = c.Remote.Instance
-			}
 
 			require.NoError(t, err, "Should load config")
 			assert.Equal(tCase.Result, c)
@@ -139,6 +138,7 @@ func TestEnvSubstitution(t *testing.T) {
 	c.Port = 2080
 	c.Cache = Duration(time.Minute)
 	c.PersistCache = DEFAULT_PERSIST_CACHE
+	c.Remote.Instance = c.Instance
 
 	t.Setenv("SPEEDTEST_TEST_LOG_LEVEL", c.LogLevel)
 	t.Setenv("SPEEDTEST_TEST_PORT", strconv.Itoa(c.Port))
@@ -147,6 +147,9 @@ func TestEnvSubstitution(t *testing.T) {
 	res, err := LoadConfig("testdata/env-config.yaml", true)
 
 	assert := assert.New(t)
+
+	assert.NotEmpty(res.Instance, "Should initialize instance from hostname")
+	assert.Equal(res.Instance, res.Remote.Instance, "Should initialize remote instance from instance")
 
 	assert.NoError(err)
 	assert.Equal(c, res)

--- a/pkg/config/testdata/valid-config-1.yaml
+++ b/pkg/config/testdata/valid-config-1.yaml
@@ -1,5 +1,6 @@
 logLevel: "warn"
 port: 80
+instance: "test"
 cache: "1m"
 persistCache: false
 speedtestCLI: "/path/to/speedtest"

--- a/pkg/config/testdata/valid-config-2.yaml
+++ b/pkg/config/testdata/valid-config-2.yaml
@@ -1,11 +1,11 @@
 logLevel: "debug"
 port: 2080
+instance: "test"
 cache: "30m"
 persistCache: true
 remote:
   enable: true
   url: "https://example.org/"
-  instance: "test"
   jobName: "testjob"
   username: "somebody"
   password: "somebody's password"

--- a/pkg/config/testdata/valid-config-3.yaml
+++ b/pkg/config/testdata/valid-config-3.yaml
@@ -1,4 +1,5 @@
 logLevel: "error"
+instance: "another-instance"
 remote:
   enable: true
   url: "https://example.org/"


### PR DESCRIPTION
Ensure we do not break anyone by keeping the remote instance option.
It will overwrite the global instance for remote write.

Closes: #131
Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>