### PR TITLE
helm: Relabel instance by default

### DIFF
--- a/manifests/helm/templates/servicemonitor.yaml
+++ b/manifests/helm/templates/servicemonitor.yaml
@@ -14,10 +14,17 @@ spec:
     - port: metrics
       scrapeTimeout: {{ .Values.servicemonitor.scrapeTimeout }}
       interval: {{ .Values.servicemonitor.interval }}
-      {{- with .Values.servicemonitor.relabelings }}
       relabelings:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- if .Values.servicemonitor.relabelings }}
+        {{- toYaml .Values.servicemonitor.relabelings | nindent 8 }}
+        {{- else }}
+        - replacement: "speedtest-exporter"
+          action: replace
+          targetLabel: job
+        - replacement: {{ .Values.config.instance | default (include "speedtest-exporter.fullname" .) | quote }}
+          action: replace
+          targetLabel: instance
+        {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -91,7 +91,11 @@ servicemonitor:
   scrapeTimeout: 1m
   # Relabelings for the ServiceMonitor
   relabelings: []
-    # - replacement: "my-cluster"
+    ## By default, these relabelings are configured.
+    # - replacement: "speedtest-exporter"
+    #   action: replace
+    #   targetLabel: job
+    # - replacement: "<instance>"
     #   action: replace
     #   targetLabel: instance
 


### PR DESCRIPTION
Relabel the instance back to what it should be, instead of what the servicemonitor wants.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>