### PR TITLE
collector: Fix flake in unit-test where sometimes the timestamp would not match

### DIFF
--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -49,13 +49,15 @@ func TestResultFromCache(t *testing.T) {
 	c, err := NewCollector(cache.NewCache(false, "", defaultCacheTime), s, "testinstance")
 	require.NoError(t, err, "Should create new Collector")
 
-	c.cache.Save(speedtest.NewFailedSpeedtestResult())
+	expectedResult := speedtest.NewFailedSpeedtestResult()
+	cachedResult := *expectedResult
+	c.cache.Save(&cachedResult)
 
 	result := c.getSpeedtestResult()
 
 	assert := assert.New(t)
 
-	assert.Equal(speedtest.NewFailedSpeedtestResult(), result)
+	assert.Equal(expectedResult, result)
 	assert.False(speedtestRan, "Should not have called the mock speedtest")
 }
 


### PR DESCRIPTION
Create a pointer to a copy of the result to ensure the returned values should match.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>