### PR TITLE
helm: Add dashboard in configmap

### DIFF
--- a/manifests/helm/dashboard.json
+++ b/manifests/helm/dashboard.json
@@ -1,0 +1,1 @@
+../../dashboard/dashboard.json

--- a/manifests/helm/templates/dashboard.yaml
+++ b/manifests/helm/templates/dashboard.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "speedtest-exporter.fullname" . }}-dashboard
+  namespace: {{ .Values.dashboard.namespace | default .Release.Namespace }}
+  labels:
+    grafana_dashboard: "1"
+    {{- include "speedtest-exporter.labels" . | nindent 4 }}
+data:
+  speedtest-exporter.json: |-
+{{ .Files.Get "dashboard.json" | indent 4 }}
+{{- end }}

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -147,3 +147,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Configuration for the Grafana dashboard
+dashboard:
+  # Enable the dashboard ConfigMap
+  enabled: false
+  # Namespace to deploy the dashboard ConfigMap into. Defaults to the release namespace when empty
+  namespace: ""


### PR DESCRIPTION
Allow grafana to discover the dashboard via sidecar.