### PR TITLE
servicemonitor: Drop pod label by default

### DIFF
--- a/manifests/helm/templates/servicemonitor.yaml
+++ b/manifests/helm/templates/servicemonitor.yaml
@@ -24,6 +24,8 @@ spec:
         - replacement: {{ .Values.config.instance | default (include "speedtest-exporter.fullname" .) | quote }}
           action: replace
           targetLabel: instance
+        - action: labeldrop
+          regex: pod
         {{- end }}
   namespaceSelector:
     matchNames:

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -98,6 +98,8 @@ servicemonitor:
     # - replacement: "<instance>"
     #   action: replace
     #   targetLabel: instance
+    # - action: labeldrop
+    #   regex: pod
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:


### PR DESCRIPTION
There should only ever be one pod at a time for an instance.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>