### PR TITLE
helm: Sync servicemonitor interval with cache duration by default

### DIFF
--- a/manifests/helm/templates/servicemonitor.yaml
+++ b/manifests/helm/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
   endpoints:
     - port: metrics
       scrapeTimeout: {{ .Values.servicemonitor.scrapeTimeout }}
-      interval: {{ .Values.servicemonitor.interval }}
+      interval: {{ .Values.servicemonitor.interval | default .Values.config.cache | quote }}
       relabelings:
         {{- if .Values.servicemonitor.relabelings }}
         {{- toYaml .Values.servicemonitor.relabelings | nindent 8 }}

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -85,8 +85,8 @@ servicemonitor:
   # Additional labels for the ServiceMonitor
   labels:
     release: monitoring
-  # Scrape interval
-  interval: 5m
+  # Scrape interval, defaults to cache duration
+  interval: ""
   # Scrape timeout
   scrapeTimeout: 1m
   # Relabelings for the ServiceMonitor


### PR DESCRIPTION
When not setting the scrape interval, use the cache duration by default.
This ensures prometheus only gets new results.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>