### PR TITLE
helm: Use deployment strategy recreate

### DIFF
--- a/manifests/helm/templates/deployment.yaml
+++ b/manifests/helm/templates/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "speedtest-exporter.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "speedtest-exporter.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
As only a single pod should exist and the pvc is ReadWriteOnce, recreate is the better strategy.